### PR TITLE
Use the official xkb name for Arabic layout, not the legacy synonym

### DIFF
--- a/pc-bios/keymaps/meson.build
+++ b/pc-bios/keymaps/meson.build
@@ -1,5 +1,5 @@
 keymaps = {
-  'ar': '-l ar',
+  'ar': '-l ara',
   'bepo': '-l fr -v dvorak',
   'cz': '-l cz',
   'da': '-l dk',


### PR DESCRIPTION
The official xkb designation for the Arabic keyboard layout is 'ara'. For the past 15 years or more, xkb has also allowed its identification through the legacy alias 'ar'. In xkeyboard-config 2.39, this alias was eliminated, causing a compilation issue for QEMU:

``` 
FAILED: pc-bios/keymaps/ar 
/home/tverous/femu/build-femu/qemu-keymap -f pc-bios/keymaps/ar -l ar
xkbcommon: ERROR: Couldn't find file "symbols/ar" in include paths
xkbcommon: ERROR: 1 include paths searched:
xkbcommon: ERROR: 	/usr/share/X11/xkb
xkbcommon: ERROR: 3 include paths could not be added:
xkbcommon: ERROR: 	/home/tverous/.config/xkb
xkbcommon: ERROR: 	/home/tverous/.xkb
xkbcommon: ERROR: 	/etc/xkb
xkbcommon: ERROR: Abandoning symbols file "(unnamed)"
xkbcommon: ERROR: Failed to compile xkb_symbols
xkbcommon: ERROR: Failed to compile keymap
```


The change in the upstream xkeyboard-config that eliminates the compat mapping is::
https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/commit/470ad2cd8fea84d7210377161d86b31999bb5ea6