### PR TITLE
Add NVMe SGL support for FEMU

### DIFF
--- a/hw/femu/dma.c
+++ b/hw/femu/dma.c
@@ -1,23 +1,29 @@
 #include "./nvme.h"
 
-void nvme_addr_read(FemuCtrl *n, hwaddr addr, void *buf, int size)
+int nvme_addr_read(FemuCtrl *n, hwaddr addr, void *buf, int size)
 {
     if (n->cmbsz && addr >= n->ctrl_mem.addr &&
         addr < (n->ctrl_mem.addr + int128_get64(n->ctrl_mem.size))) {
         memcpy(buf, (void *)&n->cmbuf[addr - n->ctrl_mem.addr], size);
+        return 0;
     } else {
         pci_dma_read(&n->parent_obj, addr, buf, size);
+        return 0;
     }
+    return 1;
 }
 
-void nvme_addr_write(FemuCtrl *n, hwaddr addr, void *buf, int size)
+int nvme_addr_write(FemuCtrl *n, hwaddr addr, void *buf, int size)
 {
     if (n->cmbsz && addr >= n->ctrl_mem.addr &&
         addr < (n->ctrl_mem.addr + int128_get64(n->ctrl_mem.size))) {
         memcpy((void *)&n->cmbuf[addr - n->ctrl_mem.addr], buf, size);
+        return 0;
     } else {
         pci_dma_write(&n->parent_obj, addr, buf, size);
+        return 0;
     }
+    return 1;
 }
 
 uint16_t nvme_map_prp(QEMUSGList *qsg, QEMUIOVector *iov, uint64_t prp1,
@@ -107,6 +113,205 @@ unmap:
     }
 
     return NVME_INVALID_FIELD | NVME_DNR;
+}
+
+static inline void nvme_sg_init(FemuCtrl *n, QEMUSGList *sg, bool dma)
+{
+    if (dma) {
+        pci_dma_sglist_init(sg, PCI_DEVICE(n), 0);
+    }
+}
+/*
+ * Map 'nsgld' data descriptors from 'segment'. The function will subtract the
+ * number of bytes mapped in len.
+ */
+static uint16_t nvme_map_sgl_data(FemuCtrl *n, QEMUSGList *sg,
+                                  NvmeSglDescriptor *segment, uint64_t nsgld,
+                                  size_t *len, NvmeCmd *cmd)
+{
+    dma_addr_t addr, trans_len;
+    uint32_t dlen;
+    uint16_t status;
+
+    for (int i = 0; i < nsgld; i++) {
+        uint8_t type = NVME_SGL_TYPE(segment[i].type);
+
+        switch (type) {
+        case NVME_SGL_DESCR_TYPE_DATA_BLOCK:
+            break;
+        case NVME_SGL_DESCR_TYPE_SEGMENT:
+        case NVME_SGL_DESCR_TYPE_LAST_SEGMENT:
+            return NVME_INVALID_NUM_SGL_DESCRS | NVME_DNR;
+        default:
+            return NVME_SGL_DESCR_TYPE_INVALID | NVME_DNR;
+        }
+
+        dlen = le32_to_cpu(segment[i].len);
+
+        if (!dlen) {
+            continue;
+        }
+
+        if (*len == 0) {
+            /*
+             * All data has been mapped, but the SGL contains additional
+             * segments and/or descriptors. The controller might accept
+             * ignoring the rest of the SGL.
+             */
+            uint32_t sgls = le32_to_cpu(n->id_ctrl.sgls);
+            if (sgls & NVME_CTRL_SGLS_EXCESS_LENGTH) {
+                break;
+            }
+
+            return NVME_DATA_SGL_LEN_INVALID | NVME_DNR;
+        }
+
+        trans_len = MIN(*len, dlen);
+
+        addr = le64_to_cpu(segment[i].addr);
+
+        if (UINT64_MAX - addr < dlen) {
+            return NVME_DATA_SGL_LEN_INVALID | NVME_DNR;
+        }
+
+        qemu_sglist_add(sg, addr, trans_len);
+
+        *len -= trans_len;
+    }
+
+    return NVME_SUCCESS;
+}
+
+uint16_t nvme_map_sgl(FemuCtrl *n, QEMUSGList *sg, NvmeSglDescriptor sgl,
+                             size_t len, NvmeCmd *cmd)
+{
+    /*
+     * Read the segment in chunks of 256 descriptors (one 4k page) to avoid
+     * dynamically allocating a potentially huge SGL. The spec allows the SGL
+     * to be larger (as in number of bytes required to describe the SGL
+     * descriptors and segment chain) than the command transfer size, so it is
+     * not bounded by MDTS.
+     */
+    const int SEG_CHUNK_SIZE = 256;
+
+    NvmeSglDescriptor segment[SEG_CHUNK_SIZE], *sgld, *last_sgld;
+    uint64_t nsgld;
+    uint32_t seg_len;
+    uint16_t status;
+    hwaddr addr;
+    int ret;
+
+    sgld = &sgl;
+    addr = le64_to_cpu(sgl.addr);
+
+    nvme_sg_init(n, sg, true);
+
+    /*
+     * If the entire transfer can be described with a single data block it can
+     * be mapped directly.
+     */
+    if (NVME_SGL_TYPE(sgl.type) == NVME_SGL_DESCR_TYPE_DATA_BLOCK) {
+        status = nvme_map_sgl_data(n, sg, sgld, 1, &len, cmd);
+        if (status) {
+            goto unmap;
+        }
+
+        goto out;
+    }
+
+    for (;;) {
+        switch (NVME_SGL_TYPE(sgld->type)) {
+        case NVME_SGL_DESCR_TYPE_SEGMENT:
+        case NVME_SGL_DESCR_TYPE_LAST_SEGMENT:
+            break;
+        default:
+            return NVME_INVALID_SGL_SEG_DESCR | NVME_DNR;
+        }
+
+        seg_len = le32_to_cpu(sgld->len);
+
+        /* check the length of the (Last) Segment descriptor */
+        if (!seg_len || seg_len & 0xf) {
+            return NVME_INVALID_SGL_SEG_DESCR | NVME_DNR;
+        }
+
+        if (UINT64_MAX - addr < seg_len) {
+            return NVME_DATA_SGL_LEN_INVALID | NVME_DNR;
+        }
+
+        nsgld = seg_len / sizeof(NvmeSglDescriptor);
+
+        while (nsgld > SEG_CHUNK_SIZE) {
+            if (nvme_addr_read(n, addr, segment, sizeof(segment))) {
+                status = NVME_DATA_TRAS_ERROR;
+                goto unmap;
+            }
+
+            status = nvme_map_sgl_data(n, sg, segment, SEG_CHUNK_SIZE,
+                                       &len, cmd);
+            if (status) {
+                goto unmap;
+            }
+
+            nsgld -= SEG_CHUNK_SIZE;
+            addr += SEG_CHUNK_SIZE * sizeof(NvmeSglDescriptor);
+        }
+
+        ret = nvme_addr_read(n, addr, segment, nsgld *
+                             sizeof(NvmeSglDescriptor));
+        if (ret) {
+            status = NVME_DATA_TRAS_ERROR;
+            goto unmap;
+        }
+
+        last_sgld = &segment[nsgld - 1];
+
+        /*
+         * If the segment ends with a Data Block, then we are done.
+         */
+        if (NVME_SGL_TYPE(last_sgld->type) == NVME_SGL_DESCR_TYPE_DATA_BLOCK) {
+            status = nvme_map_sgl_data(n, sg, segment, nsgld, &len, cmd);
+            if (status) {
+                goto unmap;
+            }
+
+            goto out;
+        }
+
+        /*
+         * If the last descriptor was not a Data Block, then the current
+         * segment must not be a Last Segment.
+         */
+        if (NVME_SGL_TYPE(sgld->type) == NVME_SGL_DESCR_TYPE_LAST_SEGMENT) {
+            status = NVME_INVALID_SGL_SEG_DESCR | NVME_DNR;
+            goto unmap;
+        }
+
+        sgld = last_sgld;
+        addr = le64_to_cpu(sgld->addr);
+
+        /*
+         * Do not map the last descriptor; it will be a Segment or Last Segment
+         * descriptor and is handled by the next iteration.
+         */
+        status = nvme_map_sgl_data(n, sg, segment, nsgld - 1, &len, cmd);
+        if (status) {
+            goto unmap;
+        }
+    }
+
+out:
+    /* if there is any residual left in len, the SGL was too short */
+    if (len) {
+        status = NVME_DATA_SGL_LEN_INVALID | NVME_DNR;
+        goto unmap;
+    }
+
+    return NVME_SUCCESS;
+
+unmap:
+    qemu_sglist_destroy(&sg);
+    return status;
 }
 
 uint16_t dma_write_prp(FemuCtrl *n, uint8_t *ptr, uint32_t len, uint64_t prp1,

--- a/hw/femu/dma.c
+++ b/hw/femu/dma.c
@@ -1,4 +1,5 @@
 #include "./nvme.h"
+#define SEG_CHUNK_SIZE 256
 
 int nvme_addr_read(FemuCtrl *n, hwaddr addr, void *buf, int size)
 {
@@ -53,7 +54,7 @@ uint16_t nvme_map_prp(QEMUSGList *qsg, QEMUIOVector *iov, uint64_t prp1,
             goto unmap;
         }
         if (len > n->page_size) {
-            uint64_t prp_list[n->max_prp_ents];
+            uint64_t *prp_list = g_malloc0(sizeof(uint64_t) * n->max_prp_ents);
             uint32_t nents, prp_trans;
             int i = 0;
 
@@ -77,6 +78,7 @@ uint16_t nvme_map_prp(QEMUSGList *qsg, QEMUIOVector *iov, uint64_t prp1,
                 }
 
                 if (!prp_ent || prp_ent & (n->page_size - 1)) {
+                    free(prp_list);
                     goto unmap;
                 }
 
@@ -90,6 +92,7 @@ uint16_t nvme_map_prp(QEMUSGList *qsg, QEMUIOVector *iov, uint64_t prp1,
                 len -= trans_len;
                 i++;
             }
+            free(prp_list);
         } else {
             if (prp2 & (n->page_size - 1)) {
                 goto unmap;
@@ -131,7 +134,7 @@ static uint16_t nvme_map_sgl_data(FemuCtrl *n, QEMUSGList *sg,
 {
     dma_addr_t addr, trans_len;
     uint32_t dlen;
-    uint16_t status;
+    //uint16_t status;
 
     for (int i = 0; i < nsgld; i++) {
         uint8_t type = NVME_SGL_TYPE(segment[i].type);
@@ -192,7 +195,6 @@ uint16_t nvme_map_sgl(FemuCtrl *n, QEMUSGList *sg, NvmeSglDescriptor sgl,
      * descriptors and segment chain) than the command transfer size, so it is
      * not bounded by MDTS.
      */
-    const int SEG_CHUNK_SIZE = 256;
 
     NvmeSglDescriptor segment[SEG_CHUNK_SIZE], *sgld, *last_sgld;
     uint64_t nsgld;
@@ -310,9 +312,10 @@ out:
     return NVME_SUCCESS;
 
 unmap:
-    qemu_sglist_destroy(&sg);
+    qemu_sglist_destroy(sg);
     return status;
 }
+
 
 uint16_t dma_write_prp(FemuCtrl *n, uint8_t *ptr, uint32_t len, uint64_t prp1,
                        uint64_t prp2)

--- a/hw/femu/femu.c
+++ b/hw/femu/femu.c
@@ -429,6 +429,7 @@ static void nvme_init_ctrl(FemuCtrl *n)
     id->psd[0].mp    = cpu_to_le16(0x9c4);
     id->psd[0].enlat = cpu_to_le32(0x10);
     id->psd[0].exlat = cpu_to_le32(0x4);
+    id->sgls = cpu_to_le32(NVME_CTRL_SGLS_SUPPORT_NO_ALIGN | NVME_CTRL_SGLS_BITBUCKET); // NVMe SGL Support
 
     n->features.arbitration     = 0x1f0f0706;
     n->features.power_mgmt      = 0;

--- a/hw/femu/nvme-io.c
+++ b/hw/femu/nvme-io.c
@@ -258,8 +258,8 @@ uint16_t nvme_rw(FemuCtrl *n, NvmeNamespace *ns, NvmeCmd *cmd, NvmeRequest *req)
     uint16_t ctrl = le16_to_cpu(rw->control);
     uint32_t nlb  = le16_to_cpu(rw->nlb) + 1;
     uint64_t slba = le64_to_cpu(rw->slba);
-    uint64_t prp1 = le64_to_cpu(rw->prp1);
-    uint64_t prp2 = le64_to_cpu(rw->prp2);
+    //uint64_t prp1 = le64_to_cpu(rw->prp1);
+    //uint64_t prp2 = le64_to_cpu(rw->prp2);
     const uint8_t lba_index = NVME_ID_NS_FLBAS_INDEX(ns->id_ns.flbas);
     const uint16_t ms = le16_to_cpu(ns->id_ns.lbaf[lba_index].ms);
     const uint8_t data_shift = ns->id_ns.lbaf[lba_index].lbads;

--- a/hw/femu/ocssd/oc12.c
+++ b/hw/femu/ocssd/oc12.c
@@ -445,8 +445,8 @@ static uint16_t oc12_read(FemuCtrl *n, NvmeNamespace *ns, NvmeCmd *cmd,
     Oc12Ctrl *ln = n->oc12_ctrl;
     Oc12RwCmd *ocrw = (Oc12RwCmd *)cmd;
     uint16_t nlb  = le16_to_cpu(ocrw->nlb) + 1;     /* # of logical blocks */
-    uint64_t prp1 = le64_to_cpu(ocrw->prp1);        /* PRP1 */
-    uint64_t prp2 = le64_to_cpu(ocrw->prp2);        /* PRP2 */
+    //uint64_t prp1 = le64_to_cpu(ocrw->prp1);        /* PRP1 */
+    //uint64_t prp2 = le64_to_cpu(ocrw->prp2);        /* PRP2 */
     uint64_t meta = le64_to_cpu(ocrw->metadata);    /* OOB */
     const uint8_t lbaid = NVME_ID_NS_FLBAS_INDEX(ns->id_ns.flbas);
     const uint8_t lbads = NVME_ID_NS_LBAF_DS(ns, lbaid);
@@ -520,8 +520,8 @@ static uint16_t oc12_write(FemuCtrl *n, NvmeNamespace *ns, NvmeCmd *cmd,
     Oc12Ctrl *ln = n->oc12_ctrl;
     Oc12RwCmd *ocrw = (Oc12RwCmd *)cmd;
     uint16_t nlb  = le16_to_cpu(ocrw->nlb) + 1;     /* # of logical blocks */
-    uint64_t prp1 = le64_to_cpu(ocrw->prp1);        /* PRP1 */
-    uint64_t prp2 = le64_to_cpu(ocrw->prp2);        /* PRP2 */
+    //uint64_t prp1 = le64_to_cpu(ocrw->prp1);        /* PRP1 */
+    //uint64_t prp2 = le64_to_cpu(ocrw->prp2);        /* PRP2 */
     uint64_t meta = le64_to_cpu(ocrw->metadata);    /* OOB */
     const uint8_t lbaid = NVME_ID_NS_FLBAS_INDEX(ns->id_ns.flbas);
     const uint8_t lbads = NVME_ID_NS_LBAF_DS(ns, lbaid);

--- a/hw/femu/zns/zns.c
+++ b/hw/femu/zns/zns.c
@@ -1175,6 +1175,9 @@ static uint16_t zns_map_dptr(FemuCtrl *n, size_t len, NvmeRequest *req)
         prp2 = le64_to_cpu(req->cmd.dptr.prp2);
 
         return nvme_map_prp(&req->qsg, &req->iov, prp1, prp2, len, n);
+    case NVME_PSDT_SGL_MPTR_CONTIGUOUS:
+    case NVME_PSDT_SGL_MPTR_SGL:
+        return nvme_map_sgl(n, &req->qsg, req->cmd.dptr.sgl, len, &req->cmd);
     default:
         return NVME_INVALID_FIELD;
     }


### PR DESCRIPTION
I noticed that the NVMe module of QEMU didn't support NVMe SGL officially when FEMU was first introduced. Now the latest QEMU has added this feature.
Now FEMU uses NVMe PRP to split a large I/O (128KB, 512KB, 1024KB) to many 4KB PRP entry (align with OS physical memory page), and the dram backend will repeat 4KB DMA(`memcpy()` actually). In my testing result, doing a 1024KB `memcpy()` is more efficient than repeating 4KB DMA 256 times, and SGL will perform a larger size of `memcpy()` with fewer operations. This may result in a loss of performance.
The modification of code is based on [hw/nvme/ctrl.c](https://github.com/vtess/FEMU/blob/master/hw/nvme/ctrl.c), no change to the current code structure. The current code in FEMU has a lot of incompatibilities with the latest QEMU NVMe module, which I have modified appropriately.