### PR TITLE
Fix incorrect comment in mark_page_invalid function

### DIFF
--- a/hw/femu/bbssd/ftl.c
+++ b/hw/femu/bbssd/ftl.c
@@ -524,7 +524,7 @@ static uint64_t ssd_advance_status(struct ssd *ssd, struct ppa *ppa, struct
     return lat;
 }
 
-/* update SSD status about one page from PG_VALID -> PG_VALID */
+/* update SSD status about one page from PG_VALID -> PG_INVALID */
 static void mark_page_invalid(struct ssd *ssd, struct ppa *ppa)
 {
     struct line_mgmt *lm = &ssd->lm;


### PR DESCRIPTION
## Description
Fix incorrect comment in the `mark_page_invalid` function. The current comment states the page status changes from `PG_VALID -> PG_VALID`, but the actual code changes it from `PG_VALID -> PG_INVALID`.

### Current comment
```c
/* update SSD status about one page from PG_VALID -> PG_VALID */
```