### PR TITLE
Fix buffer size calculation in nvme_dsm function

### DIFF
--- a/hw/femu/nvme-io.c
+++ b/hw/femu/nvme-io.c
@@ -295,7 +295,7 @@ static uint16_t nvme_dsm(FemuCtrl *n, NvmeNamespace *ns, NvmeCmd *cmd,
         uint32_t nlb;
         NvmeDsmRange *range = g_malloc0(sizeof(NvmeDsmRange) * nr);
 
-        if (dma_write_prp(n, (uint8_t *)range, sizeof(range), prp1, prp2)) {
+        if (dma_write_prp(n, (uint8_t *)range, sizeof(*range), prp1, prp2)) {
             nvme_set_error_page(n, req->sq->sqid, cmd->cid, NVME_INVALID_FIELD,
                                 offsetof(NvmeCmd, dptr.prp1), 0, ns->id);
             g_free(range);


### PR DESCRIPTION
While implementing discard/trim functionality, I discovered that slba was always coming in as 0. 
Upon investigation, I found an incorrect memory allocation in the code and fixed it.

I later noticed this issue was already mentioned in issue #165, but since no PR had been submitted to address it yet, I'm providing this fix. 

I hope this contribution helps improve the codebase.