### PR TITLE
Fix zone append not working as expected in ZNS mode

### DIFF
--- a/hw/femu/zns/zftl.c
+++ b/hw/femu/zns/zftl.c
@@ -338,18 +338,21 @@ static void *ftl_thread(void *arg)
 
             ftl_assert(req);
             switch (req->cmd.opcode) {
-            case NVME_CMD_WRITE:
-                lat = zns_write(zns, req);
-                break;
-            case NVME_CMD_READ:
-                lat = zns_read(zns, req);
-                break;
-            case NVME_CMD_DSM:
-                lat = 0;
-                break;
-            default:
-                //ftl_err("FTL received unkown request type, ERROR\n");
-                ;
+                // Fix bug: zone append not respecting configured delay
+                case NVME_CMD_ZONE_APPEND:
+                    /* Fall through */
+                case NVME_CMD_WRITE:
+                    lat = zns_write(zns, req);
+                    break;
+                case NVME_CMD_READ:
+                    lat = zns_read(zns, req);
+                    break;
+                case NVME_CMD_DSM:
+                    lat = 0;
+                    break;
+                default:
+                    //ftl_err("FTL received unkown request type, ERROR\n");
+                    ;
             }
 
             req->reqlat = lat;

--- a/hw/femu/zns/zns.c
+++ b/hw/femu/zns/zns.c
@@ -844,7 +844,8 @@ static uint16_t zns_nvme_rw(FemuCtrl *n, NvmeNamespace *ns, NvmeCmd *cmd,
     NvmeZone *zone;
     NvmeZonedResult *res = (NvmeZonedResult *)&req->cqe;
     assert(n->zoned);
-    req->is_write = (rw->opcode == NVME_CMD_WRITE) ? 1 : 0;
+    // Fix zone append not working as expected
+    req->is_write = ((rw->opcode == NVME_CMD_WRITE) || (rw->opcode == NVME_CMD_ZONE_APPEND)) ? 1 : 0;
 
     status = nvme_check_mdts(n, data_size);
     if (status) {


### PR DESCRIPTION
Solve the problem that ZNS append not working in master branch (issue #173 ).

Here the case of opcode NVME_CMD_ZONE_APPEND is also considered in req->is_write (inspired by #95 ). I assume that the time delay of the zone append operation is the same as write, and the case of opcode NVME_CMD_ZONE_APPEND is also added in *ftl_thread in zftl.c.