### PR TITLE
repair pqueue using current heap relation

### DIFF
--- a/hw/femu/lib/pqueue.c
+++ b/hw/femu/lib/pqueue.c
@@ -147,14 +147,15 @@ int pqueue_insert(pqueue_t *q, void *d)
 void pqueue_change_priority(pqueue_t *q, pqueue_pri_t new_pri, void *d)
 {
     size_t posn;
-    pqueue_pri_t old_pri = q->getpri(d);
 
     q->setpri(d, new_pri);
     posn = q->getpos(d);
-    if (q->cmppri(old_pri, new_pri))
+    if (posn > 1 &&
+        q->cmppri(q->getpri(q->d[parent(posn)]), q->getpri(d))) {
         bubble_up(q, posn);
-    else
+    } else {
         percolate_down(q, posn);
+    }
 }
 
 int pqueue_remove(pqueue_t *q, void *d)


### PR DESCRIPTION
## Description
Repair `pqueue_change_priority()` by selecting the heap-repair direction from the updated node's relationship with its current parent.


Some FEMU callers update the object's priority field before invoking `pqueue_change_priority()`. The current implementation then reads the already-updated value as `old_pri`, making `old_pri == new_pri`.

A decreased priority consequently takes the `percolate_down()` path instead of `bubble_up()`, allowing the heap root to become stale.

This is visible in FDP global-greedy GC, where an RU with a smaller vpc can remain below an RU with a larger vpc.


## Related issue
Fixes https://github.com/MoatLab/FEMU/issues/191

## Testing
I tested this by running YCSB workload A+RocksDB+XFS with 20M record and 50M operationon a 32G(25% OP) FDP SSD, the benchmark can finished after this patch.
```
2026-06-22 08:09:41 630 sec: 19070320 operations; [INSERT: Count=19070320 Max=3185573.89 Min=4.01 Avg=29.28 90=9.02 99=1123.33 99.9=2238.46 99.99=2308.09]
2026-06-22 08:09:51 640 sec: 19077555 operations; [INSERT: Count=19077555 Max=3185573.89 Min=4.01 Avg=29.63 90=9.04 99=1124.35 99.9=2238.46 99.99=3313.66]
2026-06-22 08:10:01 650 sec: 19084792 operations; [INSERT: Count=19084792 Max=3185573.89 Min=4.01 Avg=30.30 90=9.06 99=1126.40 99.9=2240.51 99.99=3319.81]
2026-06-22 08:10:11 660 sec: 19092028 operations; [INSERT: Count=19092028 Max=3185573.89 Min=4.01 Avg=30.81 90=9.08 99=1130.49 99.9=2240.51 99.99=3323.90]
2026-06-22 08:10:21 670 sec: 19099263 operations; [INSERT: Count=19099263 Max=3185573.89 Min=4.01 Avg=31.31 90=9.10 99=1131.52 99.9=2242.56 99.99=3323.90]
2026-06-22 08:10:31 680 sec: 19106499 operations; [INSERT: Count=19106499 Max=3185573.89 Min=4.01 Avg=31.65 90=9.12 99=1132.54 99.9=2246.66 99.99=3323.90]
2026-06-22 08:10:41 690 sec: 19113735 operations; [INSERT: Count=19113735 Max=3185573.89 Min=4.01 Avg=32.33 90=9.14 99=1132.54 99.9=2250.75 99.99=3325.95]
2026-06-22 08:10:51 700 sec: 19389684 operations; [INSERT: Count=19389684 Max=3185573.89 Min=4.01 Avg=32.02 90=9.10 99=1132.54 99.9=2250.75 99.99=3325.95]
2026-06-22 08:11:01 710 sec: 19736228 operations; [INSERT: Count=19736228 Max=3185573.89 Min=4.01 Avg=32.12 90=9.05 99=1132.54 99.9=2248.70 99.99=3325.95]
2026-06-22 08:11:10 719 sec: 20000000 operations; [INSERT: Count=20000000 Max=3185573.89 Min=4.01 Avg=32.20 90=9.02 99=1131.52 99.9=2248.70 99.99=3325.95]
Load runtime(sec): 719.232
Load operations(ops): 20000000
Load throughput(ops/sec): 27807.4
```
```
2026-06-22 08:45:50 2080 sec: 49481836 operations; [READ: Count=24740359 Max=11378.69 Min=1.19 Avg=35.56 90=72.45 99=120.32 99.9=314.88 99.99=820.74] [UPDATE: Count=24741477 Max=683147.26 Min=5.93 Avg=46.85 90=82.88 99=134.91 99.9=1434.62 99.99=2570.24]
2026-06-22 08:46:00 2090 sec: 49728763 operations; [READ: Count=24863702 Max=11378.69 Min=1.19 Avg=35.56 90=72.38 99=120.25 99.9=314.62 99.99=820.74] [UPDATE: Count=24865061 Max=683147.26 Min=5.93 Avg=46.86 90=82.81 99=134.78 99.9=1433.60 99.99=2570.24]
2026-06-22 08:46:10 2100 sec: 49991666 operations; [READ: Count=24995131 Max=11378.69 Min=1.19 Avg=35.54 90=72.38 99=120.13 99.9=314.37 99.99=820.74] [UPDATE: Count=24996535 Max=683147.26 Min=5.93 Avg=46.86 90=82.81 99=134.66 99.9=1432.58 99.99=2570.24]
2026-06-22 08:46:11 2101 sec: 50000000 operations; [READ: Count=24999273 Max=11378.69 Min=1.19 Avg=35.54 90=72.38 99=120.13 99.9=314.37 99.99=820.74] [UPDATE: Count=25000727 Max=683147.26 Min=5.93 Avg=46.86 90=82.81 99=134.66 99.9=1432.58 99.99=2570.24]
Run runtime(sec): 2101.04
Run operations(ops): 50000000
Run throughput(ops/sec): 23797.8
```
