### PR TITLE
femu/fdp: GC correctness + backpressure hardening (reworked)

### DIFF
--- a/hw/femu/bbssd/ftl.c
+++ b/hw/femu/bbssd/ftl.c
@@ -1153,6 +1153,36 @@ static FemuReclaimUnit *fdp_get_new_ru(struct ssd *ssd, uint16_t rgidx,
 }
 
 /*
+ * fdp_get_new_ru_spread - like fdp_get_new_ru but, when the preferred reclaim
+ * group is exhausted, fall back to any other RG that still has a free RU.
+ *
+ * This is for NON-placement (default) writes only. NVMe FDP does not bind a
+ * default write to a specific RG (the controller chooses), so spreading default
+ * writes across all RGs is spec-compliant and is what makes the FULL device
+ * usable when nrg>1. Without it, all default writes funnel to rg[0], which owns
+ * only tt_nru/nrg of the capacity, so the device wedges at ~1/nrg full with no
+ * victims yet to GC. Directive (placement) writes must NOT use this -- they are
+ * pinned to their requested RG via fdp_get_new_ru().
+ */
+static FemuReclaimUnit *fdp_get_new_ru_spread(struct ssd *ssd, uint16_t rgidx,
+                                              uint16_t ruhid)
+{
+    FemuReclaimUnit *new_ru = fdp_get_new_ru(ssd, rgidx, ruhid);
+    if (new_ru) {
+        return new_ru;
+    }
+    /* preferred RG is full; try the others in round-robin order */
+    for (uint16_t off = 1; off < (uint16_t)ssd->nrg; off++) {
+        uint16_t alt = (rgidx + off) % (uint16_t)ssd->nrg;
+        new_ru = fdp_get_new_ru(ssd, alt, ruhid);
+        if (new_ru) {
+            return new_ru;
+        }
+    }
+    return NULL;
+}
+
+/*
  * fdp_get_new_page - get next PPA from an RU's write pointer
  */
 static struct ppa fdp_get_new_page(struct ssd *ssd, FemuReclaimUnit *ru)
@@ -1182,7 +1212,8 @@ static struct ppa fdp_get_new_page(struct ssd *ssd, FemuReclaimUnit *ru)
 static FemuReclaimUnit *fdp_advance_ru_pointer(struct ssd *ssd,
                                                FemuReclaimGroup *rg,
                                                FemuRuHandle *ruh,
-                                               FemuReclaimUnit *ru)
+                                               FemuReclaimUnit *ru,
+                                               bool allow_spread)
 {
     struct ssdparams *spp = &ssd->sp;
     struct ru_mgmt *rm = rg->ru_mgmt;
@@ -1241,7 +1272,20 @@ static FemuReclaimUnit *fdp_advance_ru_pointer(struct ssd *ssd,
                 /* allocate a new RU for this RUH cuase ruh->curr_ru is full */
                 if (ruh != NULL) {
                     check_addr(wpp->blk, spp->blks_per_pl);
-                    new_ru = fdp_get_new_ru(ssd, ru->rgidx, ruh->ruhid);
+                    /*
+                     * Prefer the same RG as the RU that just filled. For the
+                     * default host-write frontier (allow_spread) fall back to any
+                     * other RG with a free RU: with nrg>1 this keeps the whole
+                     * device usable, since a single RG's capacity (tt_nru/nrg) is
+                     * otherwise exhausted during fill -- before overwrites create
+                     * GC victims -- and the device wedges at ~1/nrg. Only the
+                     * future frontier moves RG; written data keeps its RG via its
+                     * PPA. The GC destination frontier passes allow_spread=false
+                     * so GC stays pinned to the victim's RG (correct accounting).
+                     */
+                    new_ru = allow_spread ?
+                        fdp_get_new_ru_spread(ssd, ru->rgidx, ruh->ruhid) :
+                        fdp_get_new_ru(ssd, ru->rgidx, ruh->ruhid);
                     if (!new_ru) {
                         ftl_err("No free RU for ruh %d: device full - point %s L:%d\n",
                                 ruh->ruhid, __FILE__, __LINE__);
@@ -1724,20 +1768,26 @@ static void gc_write_page_fdp_style(struct ssd *ssd, struct ppa *old_ppa,
      * right after the advance.
      */
 
+    /*
+     * GC destination frontier stays PINNED to the victim's RG (allow_spread=
+     * false): a GC write must reclaim within the same reclaim group, and pinning
+     * guarantees ret_ru->rgidx == dest_ru->rgidx so the rus[dest_ru->rgidx]
+     * indexing below is correct.
+     */
     if(dest_ruh->ruh_type == NVME_RUHT_PERSISTENTLY_ISOLATED ){
         // handle ruh->ru pointer after adv
-        if( (ret_ru = fdp_advance_ru_pointer(ssd, &ssd->rg[dest_ru->rgidx], dest_ru->ruh, dest_ru)) != dest_ru){
+        if( (ret_ru = fdp_advance_ru_pointer(ssd, &ssd->rg[dest_ru->rgidx], dest_ru->ruh, dest_ru, false)) != dest_ru){
             dest_ruh->gc_ru = ret_ru;
         }
     }else if (dest_ruh->ruh_type == NVME_RUHT_INITIALLY_ISOLATED ){
         int gcruh_id = ssd->nruhs-1;
         ftl_assert( dest_ruh->ruhid == gcruh_id );
-        if( (ret_ru = fdp_advance_ru_pointer(ssd, &ssd->rg[dest_ru->rgidx], dest_ruh, dest_ru)) != dest_ru ) {
+        if( (ret_ru = fdp_advance_ru_pointer(ssd, &ssd->rg[dest_ru->rgidx], dest_ruh, dest_ru, false)) != dest_ru ) {
             //Do ugly updates
             ssd->ruhs[gcruh_id].rus[dest_ru->rgidx] = ret_ru;
             ssd->ruhs[gcruh_id].curr_ru = ret_ru;
             ssd->ruhs[gcruh_id].ruh->rus[dest_ru->rgidx] = ret_ru->nvme_ru;
-        } 
+        }
     }
     
     ftl_assert((ret_ru != NULL));
@@ -1978,7 +2028,15 @@ static int do_gc_fdp_style(struct ssd *ssd, uint16_t rgid, uint16_t ruhid,
         }
     }
 
-    mark_ru_free(ssd, rgid, victim_ru);
+    /*
+     * Free the victim into ITS OWN reclaim group, not the caller's rgid. With
+     * the cross-RG spread fallback a victim can belong to a different RG than
+     * the GC was invoked for; freeing it into the wrong RG corrupts per-RG
+     * free_ru_cnt/free_ru_list -- GC then keeps "reclaiming" without ever
+     * restoring free RUs to the RG under pressure and livelocks on fully-valid
+     * RUs. mark_ru_free uses ssd->rg[rgid], so pass the victim's rgidx.
+     */
+    mark_ru_free(ssd, victim_ru->rgidx, victim_ru);
     return 0;
 }
 
@@ -1990,7 +2048,6 @@ static uint64_t ssd_stream_write(FemuCtrl *n, struct ssd *ssd,
 {
     NvmeNamespace *ns = req->ns;
     struct ssdparams *spp = &ssd->sp;
-    FemuReclaimGroup *rg;
     FemuRuHandle *ruh;
     FemuReclaimUnit *ru;
 
@@ -2007,9 +2064,17 @@ static uint64_t ssd_stream_write(FemuCtrl *n, struct ssd *ssd,
     uint16_t pid = req->fdp_dspec;
     uint8_t dtype = req->fdp_dtype;
     uint16_t ph, rgid, ruhid;
+    /*
+     * is_placement: the host issued a valid placement directive selecting a
+     * specific reclaim group. Such writes MUST stay pinned to that RG (no cross-
+     * RG spread, no rgid re-sync). Non-placement (default) writes have no RG
+     * guarantee and may spread across RGs to use the whole nrg>1 device.
+     */
+    bool is_placement = true;
 
     if (dtype != NVME_DIRECTIVE_DATA_PLACEMENT ||
         !nvme_parse_pid(ns, pid, &ph, &rgid)) {
+        is_placement = false;
         /* generate INVALID_PID event if placement was attempted */
         if (dtype == NVME_DIRECTIVE_DATA_PLACEMENT && ssd->n->subsys) {
             NvmeEnduranceGroup *endgrp = &ssd->n->subsys->endgrp;
@@ -2035,7 +2100,6 @@ static uint64_t ssd_stream_write(FemuCtrl *n, struct ssd *ssd,
                 (unsigned)ruhid, (unsigned long)ssd->nruhs);
         ruhid = 0;
     }
-    rg = &ssd->rg[rgid];
     ruh = &ssd->ruhs[ruhid];
 
     // FDP_TRACE(ssd, "WRITE lpn=%lu-%lu dtype=%u dspec=0x%x ph=%u "
@@ -2056,11 +2120,16 @@ static uint64_t ssd_stream_write(FemuCtrl *n, struct ssd *ssd,
         //for (int gi = 0; gi < max_fg_gc && !ruh->curr_ru; gi++) {
         //    r = do_gc_fdp_style(ssd, rgid, ruhid, true);
         //    if (r == -1) break;
-            /* GC may have freed a RU; try to grab it */
-            FemuReclaimUnit *fresh = fdp_get_new_ru(ssd, rgid, ruhid);
+            /* GC may have freed a RU; try to grab it. For default writes spread
+             * across RGs so a single exhausted RG does not wedge the device when
+             * nrg>1; placement writes stay pinned to their requested RG. The new
+             * RU may come from a different RG, so index rus[] by fresh->rgidx. */
+            FemuReclaimUnit *fresh = is_placement ?
+                fdp_get_new_ru(ssd, rgid, ruhid) :
+                fdp_get_new_ru_spread(ssd, rgid, ruhid);
             if (fresh) {
-                ruh->rus[rgid] = fresh;
-                ruh->ruh->rus[rgid] = fresh->nvme_ru;
+                ruh->rus[fresh->rgidx] = fresh;
+                ruh->ruh->rus[fresh->rgidx] = fresh->nvme_ru;
                 ruh->curr_ru = fresh;
             }else{
                 ftl_err("NO reclaim Unit. Device is full error\n");
@@ -2072,6 +2141,14 @@ static uint64_t ssd_stream_write(FemuCtrl *n, struct ssd *ssd,
             return 0; /* return zero latency; write will be retried by GC */
         }
     }
+    /*
+     * Re-sync rgid to the active RU's actual RG. For default writes the spread
+     * fallback may have placed curr_ru in a different RG than requested; for
+     * placement writes curr_ru stays pinned to the requested RG so this is a
+     * no-op. Keeps the assert and per-RG bookkeeping (rus[rgid], foreground GC
+     * target, post-write rotation) consistent either way.
+     */
+    rgid = ruh->curr_ru->rgidx;
     ru = ruh->rus[rgid];
     ru = ruh->curr_ru;
     ftl_assert(ruh->curr_ru == ruh->rus[rgid]);
@@ -2117,12 +2194,17 @@ static uint64_t ssd_stream_write(FemuCtrl *n, struct ssd *ssd,
             ru->nvme_ru->ruamw--; //TODO ? Does this really decrements page KiB?
         }
 
-        /* advance RU write pointer; may allocate new RU */
-        FemuReclaimUnit *ret = fdp_advance_ru_pointer(ssd, rg, ruh, ru);
+        /* advance RU write pointer; may allocate new RU. Use the RU's OWN RG
+         * (it can differ from the request's rgid after a spread fallback) so
+         * the filled RU is classified into the correct RG's victim/full list.
+         * allow_spread only for default writes; placement writes stay pinned. */
+        FemuReclaimUnit *ret = fdp_advance_ru_pointer(ssd,
+                                   &ssd->rg[ru->rgidx], ruh, ru, !is_placement);
         if (ret && ret != ruh->curr_ru) {
-            ruh->rus[rgid] = ret;
+            /* the new active RU may have come from a different RG via spread */
+            ruh->rus[ret->rgidx] = ret;
             ruh->curr_ru = ret;
-            ruh->ruh->rus[rgid] = ret->nvme_ru;
+            ruh->ruh->rus[ret->rgidx] = ret->nvme_ru;
             ru = ret;
         } else if (!ret) {
             /*

--- a/hw/femu/bbssd/ftl.c
+++ b/hw/femu/bbssd/ftl.c
@@ -1586,10 +1586,13 @@ static FemuReclaimUnit *select_victim_ru(struct ssd *ssd, uint16_t rgid,
                 /*
                  * Also remove from the global queue (uses the still-valid pos);
                  * the global victim_ru_cnt-- and pos=0 happen at the shared
-                 * cleanup below, so do not touch them here.
+                 * cleanup below, so do not touch them here. With nrg>1 the
+                 * per-RUH queue can hold RUs from any RG, so the global twin
+                 * lives in the victim's OWN RG queue, not the caller's rgid.
                  */
                 if (victim_ru->pos) {
-                    pqueue_remove(rm->victim_ru_pq, victim_ru);
+                    pqueue_remove(ssd->rg[victim_ru->rgidx].ru_mgmt->victim_ru_pq,
+                                  victim_ru);
                 }
             }
         } else {
@@ -1667,7 +1670,12 @@ static FemuReclaimUnit *select_victim_ru(struct ssd *ssd, uint16_t rgid,
 
     victim_ru->pos = 0;
     victim_ru->ruh_pos = 0;
-    rm->victim_ru_cnt--;
+    /*
+     * Decrement the count on the victim's OWN reclaim group. For every path
+     * except cross-RG NOISY selection this is the caller's rgid; NOISY can pull
+     * a victim from another RG, whose global count must be the one adjusted.
+     */
+    ssd->rg[victim_ru->rgidx].ru_mgmt->victim_ru_cnt--;
 
     return victim_ru;
 }
@@ -2469,6 +2477,21 @@ static void ssd_trim_fdp_style(FemuCtrl *n, NvmeRequest *req, uint64_t slba,
         while ((v_ru = pqueue_peek(rm->victim_ru_pq)) != NULL) {
             pqueue_remove(rm->victim_ru_pq, v_ru);
             rm->victim_ru_cnt--;
+            mark_ru_free(ssd, v_ru->rgidx, v_ru);
+        }
+        /*
+         * GC_GLOBAL_CB keeps its full victims in victim_ru_cb, not
+         * victim_ru_pq, so drain it too or those RUs leak with a stale
+         * victim_ru_cnt on trim/format. The two queues are mutually exclusive
+         * per RG mode (the inactive one is empty here) and victim_ru_cb indexes
+         * via the same pos field, so this is safe; guard the shared count
+         * against underflow in case it was already inconsistent.
+         */
+        while ((v_ru = pqueue_peek(rm->victim_ru_cb)) != NULL) {
+            pqueue_remove(rm->victim_ru_cb, v_ru);
+            if (rm->victim_ru_cnt > 0) {
+                rm->victim_ru_cnt--;
+            }
             mark_ru_free(ssd, v_ru->rgidx, v_ru);
         }
         while ((v_ru = QTAILQ_FIRST(&rm->full_ru_list)) != NULL) {


### PR DESCRIPTION
## Summary

FDP garbage-collection hardening on top of the pqueue repair in #192, split
into focused commits. **Reworked** from the original version of this PR: the
`nrg>1` default-write-spread commit was dropped (it was incorrect, see below),
and correctness/robustness commits were added and validated on real FEMU VMs.

## Commits

1. **fix cross-RG NOISY victim accounting and CB trim drain.** Under
   `GC_NOISY_RUH_CUSTOM` with `nrg>1`, `select_victim_ru()` can return a victim
   from a different reclaim group than the caller's `rgid`. The global-queue
   removal, the delayed-GC put-back, the shared victim-count decrement,
   `mark_ru_free()`, and the implicit-RU-change event all now key off the
   victim's own reclaim group (`victim_ru->rgidx`). For every non-NOISY path
   this equals the caller `rgid`, so the default greedy path is unchanged. Also
   drains the cost-benefit victim queue in `ssd_trim_fdp_style()`, which
   previously leaked reclaim units across a format/trim on a CB device.

2. **run foreground GC until write pressure clears.** The write path capped
   foreground GC at a fixed number of passes; it now reclaims until
   `should_gc_high_fdp_style()` reports the pressure has cleared, so a busy
   device waits on reclamation instead of failing a write. Bounded by the
   reclaim-unit population; exits immediately when no victim remains.

3. **report device-full instead of asserting when GC stalls.** When GC cannot
   obtain a free destination RU, `do_gc_fdp_style()` asserted (aborting the
   emulator). It now puts the victim back on its own reclaim group's queue and
   returns -1, and `check_gc_ruh_available()` no longer dereferences a NULL
   `curr_ru`. The device degrades to a normal full outcome rather than crashing.

4. **point the initial active RU at the default reclaim group.** FDP init left
   `ruh->curr_ru` referencing the *last* reclaim group's RU, but a non-placement
   write uses reclaim group 0 and the write path advances `curr_ru` through
   `rg[rgid=0]`'s bookkeeping. With `nrg>1` this enqueued an `rg[nrg-1]` RU in
   `rg[0]`'s victim queue and later looked it up via its own group's queue with
   a stale heap position, a NULL dereference in `victim_ru_get_pri()` that
   crashed the emulator during sustained overwrites (same class as #189, but for
   `nrg>1`). Pointing `curr_ru` at `rus[0]` fixes the default path.

## Dropped from the original PR

The `nrg>1` default-write-spread commit is removed. Spreading default writes is
itself spec-legal: a write with no Data Placement Directive "uses the Placement
Handle value 0h and the controller selects the Reclaim Group for that command"
(NVMe Base Spec 2.3, Flexible Data Placement). The problem was the
implementation: it broke FEMU's invariant that each `(RUH, RG)` pair owns
exactly one active reclaim unit (the fallback allocated a *new* RU and
overwrote `ruh->rus[fallback]`, orphaning the existing one), and it did not pin
valid placement writes to their requested group. After commit 4, `nrg>1` with
default writes is crash-free but still uses only reclaim group 0. Spreading
default writes across groups, and pinning cross-group placement writes, need a
per-`(RUH,RG)` active-RU model (the single `curr_ru` pointer conflates them);
that redesign is tracked separately.

## Validation

Long-run GC stress on real FEMU VMs (Ubuntu guest, KVM), FDP mode, GC tracing on:

| Config | Result |
|---|---|
| 12 GiB, `nrg=1`, `nru=256`, ~42% fill, sustained randwrite | 30,249 GCs; `GC_START == GC_DONE`; 0 errors |
| 32 GiB, `nru=141`, `pgs_per_blk=1024`, ~84% fill (the #189 config) | 751,820 `GC_BACK_RESERT` deferrals + 1,405 GCs; 0 crashes/errors |
| 12 GiB, `nrg=2`, default writes | crashed before commit 4 (pre-existing, reproduced on `master`); after commit 4: clean, GC on rg0 only, 0 errors |

Total tens of thousands of clean GC cycles with no assert, segfault, or
device-full false positive.