### PR TITLE
femu/backend: keep going when the backend cannot be pinned

### DIFF
--- a/hw/femu/backend/dram.c
+++ b/hw/femu/backend/dram.c
@@ -62,10 +62,16 @@ int init_dram_backend(SsdDramBackend **mbe, int64_t nbytes)
     /* bind to the requested NUMA node before mlock faults the pages in */
     mbe_numa_bind(b->logical_space, nbytes);
 
+    /*
+     * Pinning keeps page faults out of the emulated latency, but it needs
+     * RLIMIT_MEMLOCK to cover the backend, which an unprivileged run rarely
+     * has. Say what that costs and carry on rather than refuse to start: the
+     * device works either way, only its timing is then subject to faults.
+     */
     if (mlock(b->logical_space, nbytes) == -1) {
-        femu_err("Failed to pin the memory backend to the host DRAM\n");
-        g_free(b->logical_space);
-        abort();
+        femu_err("cannot pin the %" PRId64 " MiB memory backend (%s); "
+                 "latencies may jitter until RLIMIT_MEMLOCK allows it\n",
+                 nbytes / MiB, strerror(errno));
     }
 
     return 0;


### PR DESCRIPTION
`init_dram_backend()` calls `abort()` when `mlock()` fails, and it fails for any
run whose `RLIMIT_MEMLOCK` does not cover the backend, which is the default on
most machines. On such a host FEMU currently dies at startup in every mode:

```
[FEMU] Err: Failed to pin the memory backend to the host DRAM
Aborted (core dumped)
```

Pinning exists to keep page faults out of the emulated latency, not to make the
device work at all. Warn with the size and the reason, say what it costs, and
carry on.

The device is unaffected otherwise; only its timing is then subject to page
faults, which the message says.

### Testing
- Built at `-Werror`, release and with the address and undefined-behaviour
  sanitizers.
- Every mode (0-5) instantiated on a host with an 8 MiB memlock limit: aborts
  before the change, comes up after it.
- Guest regression matrix on a 128-core host: black-box with page, hybrid and
  fast mapping, zoned with ZRWA, three heterogeneous namespaces, key-value, and
  black-box with FDP. All pass, no change to write amplification.

Noticed while tightening the CI step that instantiates each mode, which used
`|| true` and so had never reported that the runner could not start the device.