### PR TITLE
femu: complete a command on the queue it was bound to

### DIFF
--- a/hw/femu/nvme-io.c
+++ b/hw/femu/nvme-io.c
@@ -392,7 +392,14 @@ static void nvme_process_cq_cpl(void *arg, int index_poller)
         }
 
         pqueue_pop(pq);
-        cq = n->cq[req->sq->sqid];
+        /*
+         * A submission queue names the completion queue it reports to, and the
+         * two need not share a number. Indexing by the submission queue's own
+         * id sends the completion to whichever queue happens to carry that
+         * number -- the wrong one, with its phase tag and its interrupt -- or
+         * to none at all when no such queue exists.
+         */
+        cq = n->cq[req->sq->cqid];
         nvme_req_release_ranges(req);
         if (!cq->is_active) {
             /* CQ inactive: return request to SQ free list to avoid leak */
@@ -413,7 +420,7 @@ static void nvme_process_cq_cpl(void *arg, int index_poller)
                            n->poller_ctr[index_poller].nr_tt_ios);
             }
         }
-        n->should_isr[req->sq->sqid] = true;
+        n->should_isr[req->sq->cqid] = true;
     }
 
     if (processed == 0)


### PR DESCRIPTION
The ring-completion path takes the completion queue from the submission queue's
own identifier rather than the one Create I/O Submission Queue bound it to, and
raises the interrupt against the same index:

```c
cq = n->cq[req->sq->sqid];
...
n->should_isr[req->sq->sqid] = true;
```

The two are equal in the common setup and need not be. A host is free to point
several submission queues at one completion queue, or to use different numbers
for the pair. When they differ the completion is posted to whichever queue
carries the submission queue's number, with that queue's phase tag and its
interrupt, or is dropped when no such queue exists and the command never
completes. `should_isr` is consumed as a completion-queue index a few lines
later, so the interrupt goes to the wrong queue too.

The inline completion path already resolves this correctly with
`n->cq[sq->cqid]`; this makes the ring path agree.

### Testing
- Built at `-Werror`, release and with the address and undefined-behaviour
  sanitizers.
- Guest regression matrix on a 128-core host: black-box with page, hybrid and
  fast mapping, zoned with ZRWA, three heterogeneous namespaces, key-value, and
  black-box with FDP. All pass, write amplification unchanged.
- The common case where the two identifiers match is unaffected by construction.