### PR TITLE
femu/scripts: fail the config self-test when FEMU does not survive

### DIFF
--- a/hw/femu/scripts/ssd-config-test.sh
+++ b/hw/femu/scripts/ssd-config-test.sh
@@ -31,22 +31,55 @@ bad()  { echo "  FAIL  $*"; fail=$((fail + 1)); }
 
 # QEMU checks -device properties before it realizes the device, so a bad property
 # or a mis-escaped comma is reported whatever the host can actually support. A
-# later failure -- pinning the memory backend, no KVM -- means the arguments
-# themselves were fine, which is all this is testing.
-rejects() {
-    local out args
+# later failure -- no KVM, say -- means the arguments themselves were fine,
+# which is all this is testing.
+#
+# But "no property error in the output" is not the same as "the device came up".
+# This used to decide purely by grepping, so a binary that died on a signal, an
+# assertion or a sanitizer report scored a pass on every config: the grep found
+# no property error, and the exit status was never looked at. Report those as
+# their own outcome instead of silently counting them as success.
+#
+# Prints one word on the first line: ok, rejected, or crashed, followed by a tab
+# and the evidence.
+# what a crash looks like, and what a refused argument looks like
+CRASH_RE="Sanitizer|runtime error:|Assertion.*failed|core dumped"
+CRASH_MSG_RE="Sanitizer|runtime error:|Assertion|Aborted|Trace"
+REJECT_RE="Property '[^']*' not found|invalid parameter|short-form boolean option"
+REJECT_RE="$REJECT_RE|can't apply global|Parameter '[^']*' expects|does not exist"
+REJECT_MSG_RE="Property|invalid parameter|short-form|Parameter"
+
+check_args() {
+    local out rc args
     # Shrink the capacity for the check. What is being tested is whether FEMU
     # accepts the properties, not whether this host can hold the device, and a
     # config sized for real use would have the check allocating gigabytes.
     args="$(sed -E 's/devsz_mb=[0-9]+/devsz_mb=512/' <<<"$1")"
-    out="$(timeout 15 "$FEMU" -machine q35 $args -S -no-user-config -nodefaults \
+    # QEMU frees little at exit by design, so leak reports say nothing about the
+    # arguments; everything else a sanitizer prints does. The caller can still
+    # add options, and a caller that wants leak checking can turn it back on.
+    out="$(ASAN_OPTIONS="detect_leaks=0${ASAN_OPTIONS:+,$ASAN_OPTIONS}" \
+           timeout 15 "$FEMU" -machine q35 $args -S -no-user-config -nodefaults \
            -display none </dev/null 2>&1)"
-    if grep -qE "Property '[^']*' not found|invalid parameter|short-form boolean option|can't apply global|Parameter '[^']*' expects|does not exist" <<<"$out"; then
-        grep -m1 -E "Property|invalid parameter|short-form|Parameter" <<<"$out" | sed 's/^/        /'
-        return 0
+    rc=$?
+    # A shell reports a signal death as 128+n, so an abort is 134. Sanitizers
+    # and a failed assertion print rather than signal, so match those too.
+    if (( rc >= 128 )) || grep -qE "$CRASH_RE" <<<"$out"; then
+        printf 'crashed\t%s\n' "$(grep -m1 -E "$CRASH_MSG_RE" <<<"$out" \
+                                   || echo "exit status $rc, no message")"
+        return
     fi
-    return 1
+    if grep -qE "$REJECT_RE" <<<"$out"; then
+        printf 'rejected\t%s\n' "$(grep -m1 -E "$REJECT_MSG_RE" <<<"$out")"
+        return
+    fi
+    printf 'ok\t\n'
 }
+
+# the first word of a check_args verdict
+verdict() { sed -n '1s/\t.*//p' <<<"$1"; }
+# everything after it
+evidence() { sed -n '1s/^[a-z]*\t//p' <<<"$1"; }
 
 echo "== example configs =="
 for conf in "$HERE"/configs/*.conf; do
@@ -54,21 +87,44 @@ for conf in "$HERE"/configs/*.conf; do
     if ! args="$("$CFG" "$conf" 2>/dev/null)"; then
         bad "$name (did not expand)"; continue
     fi
-    if rejects "$args"; then bad "$name (QEMU rejected the arguments)"; else ok "$name"; fi
+    out="$(check_args "$args")"
+    case "$(verdict "$out")" in
+        ok)       ok "$name" ;;
+        rejected) bad "$name (QEMU rejected the arguments)"
+                  echo "        $(evidence "$out")" ;;
+        crashed)  bad "$name (QEMU did not survive the arguments)"
+                  echo "        $(evidence "$out")" ;;
+    esac
 done
 
-echo "== the check itself can fail (negative control) =="
-# Without this, a broken rejects() would silently pass every config above.
-if rejects "-device femu,id=nvme0,devsz_mb=1024,femu_mode=1,not_a_real_prop=7" >/dev/null; then
+echo "== the check itself can fail (negative controls) =="
+# Without these, a broken check_args() would silently pass every config above.
+bogus="-device femu,id=nvme0,devsz_mb=1024,femu_mode=1,not_a_real_prop=7"
+if [[ "$(verdict "$(check_args "$bogus")")" == rejected ]]; then
     ok "a bogus property is detected"
 else
     bad "a bogus property is detected -- the acceptance check is not working, \
 so the results above mean nothing"
 fi
-if rejects "-device femu,id=nvme0,devsz_mb=6144,namespaces=3,femu_mode=1,namespace_modes=bbssd,znssd,nossd" >/dev/null; then
+unescaped="-device femu,id=nvme0,devsz_mb=6144,namespaces=3,femu_mode=1"
+unescaped="$unescaped,namespace_modes=bbssd,znssd,nossd"
+if [[ "$(verdict "$(check_args "$unescaped")")" == rejected ]]; then
     ok "an unescaped comma in a list value is detected"
 else
     bad "an unescaped comma in a list value is detected"
+fi
+# And the same for the outcome that used to be invisible: stand in a binary that
+# dies the way an armed assertion or a sanitizer report does.
+crasher="$(mktemp)"; trap 'rm -f "$crasher"' EXIT
+printf '#!/bin/sh\nkill -ABRT $$\n' > "$crasher"; chmod +x "$crasher"
+saved_femu="$FEMU"; FEMU="$crasher"
+crash_verdict="$(verdict "$(check_args "-device femu,devsz_mb=512")")"
+FEMU="$saved_femu"
+if [[ "$crash_verdict" == crashed ]]; then
+    ok "a binary that aborts is detected"
+else
+    bad "a binary that aborts is detected -- got '$crash_verdict', so a crash \
+would be counted as a pass and the results above mean nothing"
 fi
 
 echo "== escaping and wiring =="
@@ -85,7 +141,7 @@ out="$("$CFG" "$HERE/configs/bbssd.conf" --device-only 2>/dev/null)"
     || bad "--device-only drops the -device word: $out"
 
 echo "== rejects bad input =="
-t="$(mktemp)"; trap 'rm -f "$t"' EXIT
+t="$(mktemp)"; trap 'rm -f "$t" "$crasher"' EXIT
 printf 'mode = bbssd\nnot_a_real_property = 1\n' > "$t"
 "$CFG" "$t" --check >/dev/null 2>&1 && bad "unknown property rejected" || ok "unknown property rejected"
 printf 'mode = bbssd\nfdp.nruh = 4\n' > "$t"


### PR DESCRIPTION
The config self-test decides pass or fail by grepping QEMU's output for a
property error. It never looks at the exit status, so a binary that dies on a
signal, trips an assertion or prints a sanitizer report produces no such
message and every example config is reported as accepted.

This is not hypothetical. The CI log for the config step on master
([run 33790067271](https://github.com/MoatLab/FEMU/actions/runs/33790067271))
reports `pass=17 fail=0` on a run where the device aborted during every single
invocation, because the hosted runner could not lock the memory backend. The
step could not have failed.

### What changes

`rejects()` becomes `check_args()` and reports one of three outcomes instead of
two: the arguments were accepted, the arguments were refused, or the process
did not survive them. The third is a failure; it used to be a pass.

A negative control is added for the outcome that was invisible: a stand-in
binary that aborts on every invocation must be detected, and the suite fails
loudly if it is not. The existing controls for a bogus property and an
unescaped comma are kept.

Leak reports stay excluded deliberately, so the script sets `detect_leaks=0`
itself. QEMU frees little at exit by design and a leak says nothing about
whether the arguments were accepted.

### Testing

```
SSD_CONFIG_TEST pass=18 fail=0
```

Verified against a release binary and against an address-and-undefined-behaviour
sanitizer build. Also verified that it fails when it should: pointed at a
binary that aborts, the suite reports the crash rather than passing.

The count goes from 17 to 18 because of the new control.